### PR TITLE
Explicitly use LWP::Protocol:https

### DIFF
--- a/easyapache/cloudflare.pl
+++ b/easyapache/cloudflare.pl
@@ -7,6 +7,7 @@
 
 use Archive::Tar;
 use LWP::UserAgent;
+use LWP::Protocol:https;
 use IO::Compress::Gzip qw(gzip) ;
 
 # Location from where to download the current version of mod_cloudflare


### PR DESCRIPTION
This will avoid people running into the unhelpful "Failed to download" error (see #1); instead they will get an error which makes it clear what they need to do - install HTTPS support for LWP.